### PR TITLE
Fixed a bug due to missing a constant

### DIFF
--- a/lib/apkstats/plugin.rb
+++ b/lib/apkstats/plugin.rb
@@ -1,5 +1,6 @@
 # frozen_string_literal: true
 
+require_relative "gem_version"
 require_relative "helper/bytes"
 
 require_relative "entity/apk_info"


### PR DESCRIPTION
# Summary

An error happened while executing this plugin.

```
Error loading the plugin `danger-apkstats-0.1.0`.

NameError - uninitialized constant Apkstats
/home/circleci/xxx-android/scripts/danger/vendor/bundle/ruby/2.5.0/gems/danger-apkstats-0.1.0/lib/apkstats/helper/bytes.rb:3:in `<top (required)>'
/home/circleci/xxx-android/scripts/danger/vendor/bundle/ruby/2.5.0/gems/danger-apkstats-0.1.0/lib/apkstats/plugin.rb:3:in `require_relative'
/home/circleci/xxx-android/scripts/danger/vendor/bundle/ruby/2.5.0/gems/danger-apkstats-0.1.0/lib/apkstats/plugin.rb:3:in `<top (required)>'
/home/circleci/xxx-android/scripts/danger/vendor/bundle/ruby/2.5.0/gems/danger-apkstats-0.1.0/lib/danger_plugin.rb:3:in `require'
/home/circleci/xxx-android/scripts/danger/vendor/bundle/ruby/2.5.0/gems/danger-apkstats-0.1.0/lib/danger_plugin.rb:3:in `<top (required)>'
```

# Description

Running a danger plugin locally like `bundle exec danger pr` loaded `Apkstats` module implicitly but this isn't ensured in actual use-cases.