### PR TITLE
 Add `reference_count` and `dex_count` method

### DIFF
--- a/Dangerfile.sample
+++ b/Dangerfile.sample
@@ -11,5 +11,7 @@ message(apkstats.non_required_features)
 message(apkstats.permissions)
 message(apkstats.min_sdk)
 message(apkstats.target_sdk)
+message("#{apkstats.reference_count}")
+message("#{apkstats.dex_count}")
 
 apkstats.compare_with('/spec/fixture/app-other5.apk', do_report: true)

--- a/README.md
+++ b/README.md
@@ -31,6 +31,8 @@ apkstats.non_required_features #=> Array<String> | Nil
 apkstats.permissions #=> Array<String> | Nil
 apkstats.min_sdk #=> String | Nil
 apkstats.target_sdk #=> String | Nils
+apkstats.reference_count #=> Fixnum
+apkstats.dex_count #=> Fixnum
 ```
 
 ### Get a comparison report
@@ -43,12 +45,14 @@ For example, the report will be like below.
 
 Property | Summary  
 :--- | :---
-New File Size | 1621248 Bytes. (1.55 MB
+New File Size | 1621248 Bytes. (1.55 MB)
 File Size Change | -13352 Bytes. (-13.04 KB)
 Download Size Change | +41141 Bytes. (+40.18 KB)
 Removed Required Features | - android.hardware.camera
 Removed Non-required Features | - android.hardware.camera.front (not-required)
 Removed Permissions | - android.permission.INTERNET<br>- android.permission.CAMERA
+New Number of dex file(s) | 15720
+Number of dex file(s) Change | 1
 
 ## Development
 

--- a/lib/apkstats/command/apk_analyzer.rb
+++ b/lib/apkstats/command/apk_analyzer.rb
@@ -71,12 +71,10 @@ module Apkstats::Command
     end
 
     def self.parse_reference_to_map(command_output)
-      reference_map = {}
-      command_output.split(/\r?\n/).map do |s|
-        dex_file, method_count = s.strip.split(/\t/)
-        reference_map[dex_file] = method_count
+      command_output.split(/\r?\n/).each_with_object({}) do |s, acc|
+        dex_file, method_count = s.strip.split(/\t/, 2)
+        acc[dex_file] = method_count
       end
-      reference_map
     end
 
     private

--- a/lib/apkstats/command/apk_analyzer.rb
+++ b/lib/apkstats/command/apk_analyzer.rb
@@ -38,11 +38,17 @@ module Apkstats::Command
     end
 
     def reference_count(apk_filepath)
-      ApkAnalyzer.parse_reference_to_map(run_command("dex", "references", apk_filepath)).values.map { |v| v.to_i }.sum.to_s
+      ApkAnalyzer.parse_reference_to_map(run_command("dex", "references", apk_filepath))
+        .values
+        .map(&:to_i)
+        .inject(:+)
+        .to_s
     end
 
     def dex_count(apk_filepath)
-      ApkAnalyzer.parse_reference_to_map(run_command("dex", "references", apk_filepath)).size.to_s
+      ApkAnalyzer.parse_reference_to_map(run_command("dex", "references", apk_filepath))
+        .size
+        .to_s
     end
 
     def self.parse_permissions(command_output)
@@ -69,10 +75,10 @@ module Apkstats::Command
 
     def self.parse_reference_to_map(command_output)
       reference_map = {}
-      command_output.split(/\r?\n/).map { |s| 
+      command_output.split(/\r?\n/).map do |s|
         dex_file, method_count = s.strip.split(/\t/)
         reference_map[dex_file] = method_count
-      }
+      end
       reference_map
     end
 

--- a/lib/apkstats/command/apk_analyzer.rb
+++ b/lib/apkstats/command/apk_analyzer.rb
@@ -37,7 +37,7 @@ module Apkstats::Command
       run_command("manifest", "target-sdk", apk_filepath)
     end
 
-    def reference_count(apk_filepath)
+    def method_reference_count(apk_filepath)
       ApkAnalyzer.parse_reference_to_map(run_command("dex", "references", apk_filepath))
         .values
         .map(&:to_i)

--- a/lib/apkstats/command/apk_analyzer.rb
+++ b/lib/apkstats/command/apk_analyzer.rb
@@ -42,13 +42,10 @@ module Apkstats::Command
         .values
         .map(&:to_i)
         .inject(:+)
-        .to_s
     end
 
     def dex_count(apk_filepath)
-      ApkAnalyzer.parse_reference_to_map(run_command("dex", "references", apk_filepath))
-        .size
-        .to_s
+      ApkAnalyzer.parse_reference_to_map(run_command("dex", "references", apk_filepath)).size
     end
 
     def self.parse_permissions(command_output)

--- a/lib/apkstats/command/apk_analyzer.rb
+++ b/lib/apkstats/command/apk_analyzer.rb
@@ -37,6 +37,14 @@ module Apkstats::Command
       run_command("manifest", "target-sdk", apk_filepath)
     end
 
+    def reference_count(apk_filepath)
+      ApkAnalyzer.parse_reference_to_map(run_command("dex", "references", apk_filepath)).values.map { |v| v.to_i }.sum.to_s
+    end
+
+    def dex_count(apk_filepath)
+      ApkAnalyzer.parse_reference_to_map(run_command("dex", "references", apk_filepath)).size.to_s
+    end
+
     def self.parse_permissions(command_output)
       command_output.split(/\r?\n/).map { |s| to_permission(s) }
     end
@@ -57,6 +65,15 @@ module Apkstats::Command
       name, kind, tail = str.strip.split(/\s/, 3)
 
       ::Apkstats::Entity::Feature.new(name, not_required: kind == "not-required", implied_reason: kind == "implied:" && tail)
+    end
+
+    def self.parse_reference_to_map(command_output)
+      reference_map = {}
+      command_output.split(/\r?\n/).map { |s| 
+        dex_file, method_count = s.strip.split(/\t/)
+        reference_map[dex_file] = method_count
+      }
+      reference_map
     end
 
     private

--- a/lib/apkstats/command/executable.rb
+++ b/lib/apkstats/command/executable.rb
@@ -21,7 +21,7 @@ module Apkstats::Command
     #     permissions: Array<String>,
     #     min_sdk: String,
     #     target_sdk: String,
-    #     reference_count: Integer,
+    #     method_reference_count: Integer,
     #     dex_count: Integer,
     #   },
     #   other: {
@@ -32,7 +32,7 @@ module Apkstats::Command
     #     permissions: Array<String>,
     #     min_sdk: String,
     #     target_sdk: String,
-    #     reference_count: Integer,
+    #     method_reference_count: Integer,
     #     dex_count: Integer,
     #   },
     #   diff: {
@@ -52,7 +52,7 @@ module Apkstats::Command
     #     },
     #     min_sdk: Array<String>,
     #     target_sdk: Array<String>,
-    #     reference_count: Integer,
+    #     method_reference_count: Integer,
     #     dex_count: Integer,
     #   }
     # }

--- a/lib/apkstats/command/executable.rb
+++ b/lib/apkstats/command/executable.rb
@@ -21,6 +21,8 @@ module Apkstats::Command
     #     permissions: Array<String>,
     #     min_sdk: String,
     #     target_sdk: String,
+    #     reference_count: Integer,
+    #     dex_count: Integer,
     #   },
     #   other: {
     #     file_size: Integer,
@@ -30,6 +32,8 @@ module Apkstats::Command
     #     permissions: Array<String>,
     #     min_sdk: String,
     #     target_sdk: String,
+    #     reference_count: Integer,
+    #     dex_count: Integer,
     #   },
     #   diff: {
     #     file_size: Integer,
@@ -48,6 +52,8 @@ module Apkstats::Command
     #     },
     #     min_sdk: Array<String>,
     #     target_sdk: Array<String>,
+    #     reference_count: Integer,
+    #     dex_count: Integer,
     #   }
     # }
     #

--- a/lib/apkstats/entity/apk_info.rb
+++ b/lib/apkstats/entity/apk_info.rb
@@ -10,12 +10,12 @@ module Apkstats::Entity
       permissions
       min_sdk
       target_sdk
-      reference_count
+      method_reference_count
       dex_count
     ).freeze
 
     # Integer
-    attr_accessor :file_size, :download_size, :reference_count, :dex_count
+    attr_accessor :file_size, :download_size, :method_reference_count, :dex_count
 
     # String
     attr_accessor :min_sdk, :target_sdk

--- a/lib/apkstats/entity/apk_info.rb
+++ b/lib/apkstats/entity/apk_info.rb
@@ -10,10 +10,12 @@ module Apkstats::Entity
       permissions
       min_sdk
       target_sdk
+      reference_count
+      dex_count
     ).freeze
 
     # Integer
-    attr_accessor :file_size, :download_size
+    attr_accessor :file_size, :download_size, :reference_count, :dex_count
 
     # String
     attr_accessor :min_sdk, :target_sdk

--- a/lib/apkstats/entity/apk_info_diff.rb
+++ b/lib/apkstats/entity/apk_info_diff.rb
@@ -63,5 +63,15 @@ module Apkstats::Entity
       # String
       [@base[__method__], @other[__method__]].uniq
     end
+
+    def reference_count
+      # Integer
+      @base[__method__].to_i - @other[__method__].to_i
+    end
+
+    def dex_count
+      # Integer
+      @base[__method__].to_i - @other[__method__].to_i
+    end
   end
 end

--- a/lib/apkstats/entity/apk_info_diff.rb
+++ b/lib/apkstats/entity/apk_info_diff.rb
@@ -64,7 +64,7 @@ module Apkstats::Entity
       [@base[__method__], @other[__method__]].uniq
     end
 
-    def reference_count
+    def method_reference_count
       # Integer
       @base[__method__].to_i - @other[__method__].to_i
     end

--- a/lib/apkstats/plugin.rb
+++ b/lib/apkstats/plugin.rb
@@ -249,7 +249,7 @@ module Danger
     # @return [Fixnum] return positive value if exists, otherwise -1.
     def method_reference_count(_opts = {})
       result = run_command(__method__)
-      result ? result.to_i : -1
+      result || -1
     end
 
     # Show the number of dex of your apk file.
@@ -257,7 +257,7 @@ module Danger
     # @return [Fixnum] return positive value if exists, otherwise -1.
     def dex_count(_opts = {})
       result = run_command(__method__)
-      result ? result.to_i : -1
+      result || -1
     end
 
     private

--- a/lib/apkstats/plugin.rb
+++ b/lib/apkstats/plugin.rb
@@ -54,7 +54,7 @@ module Danger
   #
   # @example Show the methods reference count of your apk file.
   #
-  #         apkstats.reference_count
+  #         apkstats.method_reference_count
   #
   # @example Show the number of dex of your apk file.
   #
@@ -145,12 +145,12 @@ module Danger
           md << "Download Size Change | #{size.to_s_b} Bytes. (#{size.to_s_kb} KB) " << "\n"
         end
 
-        result[:base][:reference_count].tap do |reference_count|
-          md << "New Reference Count | #{reference_count}" << "\n"
+        result[:base][:method_reference_count].tap do |method_reference_count|
+          md << "New Method Reference Count | #{method_reference_count}" << "\n"
         end
 
-        diff[:reference_count].tap do |reference_count|
-          md << "Reference Count Change | #{reference_count}" << "\n"
+        diff[:method_reference_count].tap do |method_reference_count|
+          md << "Method Reference Count Change | #{method_reference_count}" << "\n"
         end
 
         result[:base][:dex_count].tap do |dex_count|
@@ -247,7 +247,7 @@ module Danger
     # Show the methods reference count of your apk file.
     #
     # @return [Fixnum] return positive value if exists, otherwise -1.
-    def reference_count(_opts = {})
+    def method_reference_count(_opts = {})
       result = run_command(__method__)
       result ? result.to_i : -1
     end

--- a/lib/apkstats/plugin.rb
+++ b/lib/apkstats/plugin.rb
@@ -52,6 +52,14 @@ module Danger
   #
   #         apkstats.target_sdk
   #
+  # @example Show the methods reference count of your apk file.
+  #
+  #         apkstats.reference_count
+  #
+  # @example Show the number of dex of your apk file.
+  #
+  #         apkstats.dex_count
+  #
   # @see  Jumpei Matsuda/danger-apkstats
   # @tags android, apk_stats
   #
@@ -137,6 +145,22 @@ module Danger
           md << "Download Size Change | #{size.to_s_b} Bytes. (#{size.to_s_kb} KB) " << "\n"
         end
 
+        result[:base][:reference_count].tap do |reference_count|
+          md << "New Reference Count | #{reference_count}" << "\n"
+        end
+
+        diff[:reference_count].tap do |reference_count|
+          md << "Reference Count Change | #{reference_count}"
+        end
+
+        result[:base][:dex_count].tap do |dex_count|
+          md << "New Number of dex file(s) | #{dex_count}" << "\n"
+        end
+
+        diff[:dex_count].tap do |dex_count|
+          md << "Number of dex file(s) Change | #{dex_count}"
+        end
+
         report_hash_and_arrays = lambda { |key, name|
           list_up_entities = lambda { |type_key, label|
             diff[key][type_key].tap do |features|
@@ -218,6 +242,22 @@ module Danger
     # @return [String, Nil] return nil unless retrieved.
     def target_sdk(_opts = {})
       run_command(__method__)
+    end
+
+    # Show the methods reference count of your apk file.
+    #
+    # @return [Fixnum] return positive value if exists, otherwise -1.
+    def reference_count(_opts = {})
+      result = run_command(__method__)
+      result ? result.to_i : -1
+    end
+
+    # Show the number of dex of your apk file.
+    #
+    # @return [Fixnum] return positive value if exists, otherwise -1.
+    def dex_count(_opts = {})
+      result = run_command(__method__)
+      result ? result.to_i : -1
     end
 
     private

--- a/lib/apkstats/plugin.rb
+++ b/lib/apkstats/plugin.rb
@@ -130,7 +130,7 @@ module Danger
         result[:base][:file_size].tap do |file_size|
           size = Apkstats::Helper::Bytes.from_b(file_size)
 
-          md << "New File Size | #{size.to_b} Bytes. (#{size.to_mb} MB " << "\n"
+          md << "New File Size | #{size.to_b} Bytes. (#{size.to_mb} MB) " << "\n"
         end
 
         diff[:file_size].tap do |file_size|
@@ -150,7 +150,7 @@ module Danger
         end
 
         diff[:reference_count].tap do |reference_count|
-          md << "Reference Count Change | #{reference_count}"
+          md << "Reference Count Change | #{reference_count}" << "\n"
         end
 
         result[:base][:dex_count].tap do |dex_count|
@@ -158,7 +158,7 @@ module Danger
         end
 
         diff[:dex_count].tap do |dex_count|
-          md << "Number of dex file(s) Change | #{dex_count}"
+          md << "Number of dex file(s) Change | #{dex_count}" << "\n"
         end
 
         report_hash_and_arrays = lambda { |key, name|

--- a/lib/apkstats/plugin.rb
+++ b/lib/apkstats/plugin.rb
@@ -89,7 +89,7 @@ module Danger
     # @return [String]
     attr_accessor :apk_filepath
 
-    # rubocop:disable Metrics/AbcSize
+    # rubocop:disable Metrics/AbcSize, Metrics/MethodLength
 
     # Get stats of two apk files and calculate diffs between them.
     #
@@ -186,7 +186,7 @@ module Danger
       e.backtrace&.each { |line| STDOUT.puts line }
     end
 
-    # rubocop:enable Metrics/AbcSize
+    # rubocop:enable Metrics/AbcSize, Metrics/MethodLength
 
     # Show the file size of your apk file.
     #

--- a/spec/command/apk_analyzer_spec.rb
+++ b/spec/command/apk_analyzer_spec.rb
@@ -55,6 +55,14 @@ module Apkstats::Command
       it "target_sdk should return target sdk" do
         expect(command.target_sdk(apk_base)).to eq("28")
       end
+
+      it "reference_count should return reference count" do
+        expect(command.reference_count(apk_base)).to eq(15720.to_s)
+      end
+
+      it "dex_count should return dex count" do
+        expect(command.dex_count(apk_base)).to eq(1.to_s)
+      end
     end
 
     context "to_permission" do

--- a/spec/command/apk_analyzer_spec.rb
+++ b/spec/command/apk_analyzer_spec.rb
@@ -57,9 +57,9 @@ module Apkstats::Command
         expect(command.target_sdk(apk_base)).to eq("28")
       end
 
-      it "reference_count should return reference count" do
-        expect(command.reference_count(apk_base)).to eq(15_720.to_s)
-        expect(command.reference_count(apk_method64k)).to eq(124_304.to_s)
+      it "method_reference_count should return reference count" do
+        expect(command.method_reference_count(apk_base)).to eq(15_720.to_s)
+        expect(command.method_reference_count(apk_method64k)).to eq(124_304.to_s)
       end
 
       it "dex_count should return dex count" do

--- a/spec/command/apk_analyzer_spec.rb
+++ b/spec/command/apk_analyzer_spec.rb
@@ -58,8 +58,8 @@ module Apkstats::Command
       end
 
       it "reference_count should return reference count" do
-        expect(command.reference_count(apk_base)).to eq(15720.to_s)
-        expect(command.reference_count(apk_method64k)).to eq(124304.to_s)
+        expect(command.reference_count(apk_base)).to eq(15_720.to_s)
+        expect(command.reference_count(apk_method64k)).to eq(124_304.to_s)
       end
 
       it "dex_count should return dex count" do

--- a/spec/command/apk_analyzer_spec.rb
+++ b/spec/command/apk_analyzer_spec.rb
@@ -10,6 +10,7 @@ module Apkstats::Command
     let(:apk_other3) { fixture_path + "app-other3.apk" }
     let(:apk_other4) { fixture_path + "app-other4.apk" }
     let(:apk_other5) { fixture_path + "app-other5.apk" }
+    let(:apk_method64k) { fixture_path + "app-method64k.apk" }
 
     it "should use custom path if set" do
       expect(ApkAnalyzer.new({}).command_path).to eq("#{ENV.fetch('ANDROID_HOME')}/tools/bin/apkanalyzer")
@@ -58,10 +59,12 @@ module Apkstats::Command
 
       it "reference_count should return reference count" do
         expect(command.reference_count(apk_base)).to eq(15720.to_s)
+        expect(command.reference_count(apk_method64k)).to eq(124304.to_s)
       end
 
       it "dex_count should return dex count" do
         expect(command.dex_count(apk_base)).to eq(1.to_s)
+        expect(command.dex_count(apk_method64k)).to eq(2.to_s)
       end
     end
 

--- a/spec/command/apk_analyzer_spec.rb
+++ b/spec/command/apk_analyzer_spec.rb
@@ -58,13 +58,13 @@ module Apkstats::Command
       end
 
       it "method_reference_count should return reference count" do
-        expect(command.method_reference_count(apk_base)).to eq(15_720.to_s)
-        expect(command.method_reference_count(apk_method64k)).to eq(124_304.to_s)
+        expect(command.method_reference_count(apk_base)).to eq(15_720)
+        expect(command.method_reference_count(apk_method64k)).to eq(124_304)
       end
 
       it "dex_count should return dex count" do
-        expect(command.dex_count(apk_base)).to eq(1.to_s)
-        expect(command.dex_count(apk_method64k)).to eq(2.to_s)
+        expect(command.dex_count(apk_base)).to eq(1)
+        expect(command.dex_count(apk_method64k)).to eq(2)
       end
     end
 

--- a/spec/entity/apk_info_diff_spec.rb
+++ b/spec/entity/apk_info_diff_spec.rb
@@ -31,7 +31,7 @@ module Apkstats::Entity
                                        ]),
           min_sdk: "16",
           target_sdk: "26",
-          reference_count: 20000,
+          reference_count: 20_000,
           dex_count: 1,
       }
     end

--- a/spec/entity/apk_info_diff_spec.rb
+++ b/spec/entity/apk_info_diff_spec.rb
@@ -31,7 +31,7 @@ module Apkstats::Entity
                                        ]),
           min_sdk: "16",
           target_sdk: "26",
-          reference_count: 20_000,
+          method_reference_count: 20_000,
           dex_count: 1,
       }
     end
@@ -59,7 +59,7 @@ module Apkstats::Entity
                                        ]),
           min_sdk: "21",
           target_sdk: "27",
-          reference_count: base_apk_values[:reference_count] + 2000,
+          method_reference_count: base_apk_values[:method_reference_count] + 2000,
           dex_count: base_apk_values[:dex_count] + 1,
       }
     end
@@ -109,7 +109,7 @@ module Apkstats::Entity
       )
       expect(diff.min_sdk).to eq(%w(16 21))
       expect(diff.target_sdk).to eq(%w(26 27))
-      expect(diff.reference_count).to eq(-2000)
+      expect(diff.method_reference_count).to eq(-2000)
       expect(diff.dex_count).to eq(-1)
     end
   end

--- a/spec/entity/apk_info_diff_spec.rb
+++ b/spec/entity/apk_info_diff_spec.rb
@@ -31,6 +31,8 @@ module Apkstats::Entity
                                        ]),
           min_sdk: "16",
           target_sdk: "26",
+          reference_count: 20000,
+          dex_count: 1,
       }
     end
 
@@ -57,6 +59,8 @@ module Apkstats::Entity
                                        ]),
           min_sdk: "21",
           target_sdk: "27",
+          reference_count: base_apk_values[:reference_count] + 2000,
+          dex_count: base_apk_values[:dex_count] + 1,
       }
     end
 
@@ -105,6 +109,8 @@ module Apkstats::Entity
       )
       expect(diff.min_sdk).to eq(%w(16 21))
       expect(diff.target_sdk).to eq(%w(26 27))
+      expect(diff.reference_count).to eq(-2000)
+      expect(diff.dex_count).to eq(-1)
     end
   end
 end

--- a/spec/entity/apk_info_spec.rb
+++ b/spec/entity/apk_info_spec.rb
@@ -22,6 +22,8 @@ module Apkstats::Entity
                                        ]),
           min_sdk: "16",
           target_sdk: "26",
+          reference_count: 20000,
+          dex_count: 1,
       }
     end
 

--- a/spec/entity/apk_info_spec.rb
+++ b/spec/entity/apk_info_spec.rb
@@ -22,7 +22,7 @@ module Apkstats::Entity
                                        ]),
           min_sdk: "16",
           target_sdk: "26",
-          reference_count: 20000,
+          reference_count: 20_000,
           dex_count: 1,
       }
     end

--- a/spec/entity/apk_info_spec.rb
+++ b/spec/entity/apk_info_spec.rb
@@ -22,7 +22,7 @@ module Apkstats::Entity
                                        ]),
           min_sdk: "16",
           target_sdk: "26",
-          reference_count: 20_000,
+          method_reference_count: 20_000,
           dex_count: 1,
       }
     end


### PR DESCRIPTION
This PR adds to show dex reference count and number of dex files into the apk file with this plugin.