### PR TITLE
Deprecate ANDROID_HOME usages

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -6,8 +6,8 @@ executors:
     - image: circleci/android:api-29
     working_directory: ~/workspace
     environment:
-      ANDROID_HOME: /home/circleci/sdk/cmdline-tools # deprecated and fake
       ANDROID_SDK_ROOT: /home/circleci/sdk
+      APKANALYZER_PATH: /home/circleci/sdk/cmdline-tools/tools/bin/apkanalyzer
 
   ruby:
     docker:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -100,4 +100,5 @@ workflows:
       - lint
       - test:
           matrix:
-            ruby_version: [2.5.8, 2.6.6, 2.7.1]
+            parameters:
+              ruby_version: [2.5.8, 2.6.6, 2.7.1]

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -99,11 +99,5 @@ workflows:
     jobs:
       - lint
       - test:
-          name: test@2.5.8
-          ruby_version: 2.5.8
-      - test:
-          name: test@2.6.6
-          ruby_version: 2.6.6
-      - test:
-          name: test@2.7.1
-          ruby_version: 2.7.1
+          matrix:
+            ruby_version: [2.5.8, 2.6.6, 2.7.1]

--- a/README.md
+++ b/README.md
@@ -7,9 +7,15 @@ This allows you to get attributes of your application file (apk) and report a su
 
 ## Installation
 
-`gem install danger-apkstats`
+`gem install danger-apkstats` or add `danger-apkstats` to your Gemfile.
 
-Also, you need to have ANDROID_HOME which indicates sdk location in your environment variables.
+Please specify the path of apkanalyzer in your Dangerfile.
+
+```ruby
+apkstats.apkanalyzer_path='/path/to/apkanalyzer'
+```
+
+`ANDROID_HOME` has been officially deprecated. `ANDROID_SDK_ROOT` is similar to `ANDROID_HOME` but differs actually. And also, the change indicated the possibility of further deprecations and/or breaking changes in the Android SDK structure.
 
 ## Usage
 

--- a/lib/apkstats/command/apk_analyzer.rb
+++ b/lib/apkstats/command/apk_analyzer.rb
@@ -5,7 +5,7 @@ module Apkstats::Command
     include Apkstats::Command::Executable
 
     def initialize(opts)
-      @command_path = opts[:command_path] || "#{ENV.fetch('ANDROID_HOME')}/tools/bin/apkanalyzer"
+      @command_path = opts.fetch(:command_path)
     end
 
     def file_size(apk_filepath)

--- a/lib/apkstats/plugin.rb
+++ b/lib/apkstats/plugin.rb
@@ -283,7 +283,7 @@ module Danger
       return @apkanalyzer_command if defined?(@apkanalyzer_command)
 
       command_path = apkanalyzer_path || begin
-                                           android_home = ENV['ANDROID_HOME']
+                                           android_home = ENV["ANDROID_HOME"]
 
                                            if android_home
                                              warn("apkstats will not use ANDROID_HOME in further versions because ANDROID_HOME has been officially deprecated.")
@@ -297,11 +297,11 @@ module Danger
       @apkanalyzer_command = Apkstats::Command::ApkAnalyzer.new(command_path: command_path)
     end
 
-    # @param [StandardError] e a happened error
+    # @param [StandardError] err a happened error
     # @return [NilClass]
-    def on_error(e)
-      STDERR.puts e.message
-      e.backtrace&.each { |line| STDERR.puts line }
+    def on_error(err)
+      warn e.message
+      e.backtrace&.each { |line| warn line }
       nil
     end
   end

--- a/lib/apkstats/plugin.rb
+++ b/lib/apkstats/plugin.rb
@@ -300,8 +300,8 @@ module Danger
     # @param [StandardError] err a happened error
     # @return [NilClass]
     def on_error(err)
-      warn e.message
-      e.backtrace&.each { |line| warn line }
+      warn err.message
+      err.backtrace&.each { |line| warn line }
       nil
     end
   end

--- a/lib/apkstats/plugin.rb
+++ b/lib/apkstats/plugin.rb
@@ -74,6 +74,9 @@ module Danger
     private_constant(:COMMAND_TYPE_MAP)
 
     # @deprecated this field have no effect
+    # This will be removed in further versions
+    #
+    # @return [String] _
     attr_accessor :command_type
 
     # *Required*
@@ -83,9 +86,11 @@ module Danger
     attr_accessor :apkanalyzer_path
 
     # @deprecated Use apkanalyzer_path instead
+    # @return [String] _
     alias command_path apkanalyzer_path
 
     # @deprecated Use apkanalyzer_path= instead
+    # @return [String] _
     alias command_path= apkanalyzer_path=
 
     # *Required*

--- a/lib/apkstats/plugin.rb
+++ b/lib/apkstats/plugin.rb
@@ -64,24 +64,29 @@ module Danger
   # @tags android, apk_stats
   #
   class DangerApkstats < Plugin
+    class Error < StandardError; end
+
+    # @deprecated this field have no effect
     COMMAND_TYPE_MAP = {
       apk_analyzer: Apkstats::Command::ApkAnalyzer,
     }.freeze
 
     private_constant(:COMMAND_TYPE_MAP)
 
-    # *Optional*
-    # A command type to be run.
-    # One of keys of COMMAND_TYPE_MAP
-    #
-    # @return [Symbol, Nil] _
+    # @deprecated this field have no effect
     attr_accessor :command_type
 
-    # *Optional*
-    # A custom command path
+    # *Required*
+    # A path of apkanalyzer command
     #
-    # @return [Symbol, Nil] _
-    attr_accessor :command_path
+    # @return [String] _
+    attr_accessor :apkanalyzer_path
+
+    # @deprecated Use apkanalyzer_path instead
+    alias command_path apkanalyzer_path
+
+    # @deprecated Use apkanalyzer_path= instead
+    alias command_path= apkanalyzer_path=
 
     # *Required*
     # Your target apk filepath.
@@ -183,7 +188,7 @@ module Danger
     rescue StandardError => e
       warn("apkstats failed to execute the command due to #{e.message}")
 
-      e.backtrace&.each { |line| STDOUT.puts line }
+      on_error(e)
     end
 
     # rubocop:enable Metrics/AbcSize, Metrics/MethodLength
@@ -192,7 +197,7 @@ module Danger
     #
     # @return [Fixnum] return positive value if exists, otherwise -1.
     def file_size(_opts = {})
-      result = run_command(__method__)
+      result = run_command(apkanalyzer_command, __method__)
       result ? result.to_i : -1
     end
 
@@ -200,7 +205,7 @@ module Danger
     #
     # @return [Fixnum] return positive value if exists, otherwise -1.
     def download_size(_opts = {})
-      result = run_command(__method__)
+      result = run_command(apkanalyzer_command, __method__)
       result ? result.to_i : -1
     end
 
@@ -209,7 +214,7 @@ module Danger
     #
     # @return [Array<String>, Nil] return nil unless retrieved.
     def required_features(_opts = {})
-      result = run_command(__method__)
+      result = run_command(apkanalyzer_command, __method__)
       result ? result.to_a : nil
     end
 
@@ -218,7 +223,7 @@ module Danger
     #
     # @return [Array<String>, Nil] return nil unless retrieved.
     def non_required_features(_opts = {})
-      result = run_command(__method__)
+      result = run_command(apkanalyzer_command, __method__)
       result ? result.to_a : nil
     end
 
@@ -226,7 +231,7 @@ module Danger
     #
     # @return [Array<String>, Nil] return nil unless retrieved.
     def permissions(_opts = {})
-      result = run_command(__method__)
+      result = run_command(apkanalyzer_command, __method__)
       result ? result.to_a : nil
     end
 
@@ -234,21 +239,21 @@ module Danger
     #
     # @return [String, Nil] return nil unless retrieved.
     def min_sdk(_opts = {})
-      run_command(__method__)
+      run_command(apkanalyzer_command, __method__)
     end
 
     # Show the target sdk version of your apk file.
     #
     # @return [String, Nil] return nil unless retrieved.
     def target_sdk(_opts = {})
-      run_command(__method__)
+      run_command(apkanalyzer_command, __method__)
     end
 
     # Show the methods reference count of your apk file.
     #
     # @return [Fixnum] return positive value if exists, otherwise -1.
     def method_reference_count(_opts = {})
-      result = run_command(__method__)
+      result = run_command(apkanalyzer_command, __method__)
       result || -1
     end
 
@@ -256,27 +261,48 @@ module Danger
     #
     # @return [Fixnum] return positive value if exists, otherwise -1.
     def dex_count(_opts = {})
-      result = run_command(__method__)
+      result = run_command(apkanalyzer_command, __method__)
       result || -1
     end
 
     private
 
-    def run_command(name)
+    # @param [Apkstats::Command::Executable] command a wrapper class of a command
+    # @param [String] name an attribute name
+    def run_command(command, name)
       raise "#{command.command_path} is not found or is not executable" unless command.executable?
 
       return command.send(name, apk_filepath)
     rescue StandardError => e
       warn("apkstats failed to execute the command #{name} due to #{e.message}")
 
-      e.backtrace&.each { |line| puts line }
-
-      nil
+      on_error(e)
     end
 
-    def command
-      command_type ||= :apk_analyzer
-      @command ||= COMMAND_TYPE_MAP[command_type.to_sym].new(command_path: command_path)
+    def apkanalyzer_command
+      return @apkanalyzer_command if defined?(@apkanalyzer_command)
+
+      command_path = apkanalyzer_path || begin
+                                           android_home = ENV['ANDROID_HOME']
+
+                                           if android_home
+                                             warn("apkstats will not use ANDROID_HOME in further versions because ANDROID_HOME has been officially deprecated.")
+                                           else
+                                             raise Error, "Please specify apkanalyzer_path to execute apkstats"
+                                           end
+
+                                           "#{android_home}/tools/bin/apkanalyzer"
+                                         end
+
+      @apkanalyzer_command = Apkstats::Command::ApkAnalyzer.new(command_path: command_path)
+    end
+
+    # @param [StandardError] e a happened error
+    # @return [NilClass]
+    def on_error(e)
+      STDERR.puts e.message
+      e.backtrace&.each { |line| STDERR.puts line }
+      nil
     end
   end
 end

--- a/spec/apkstats_spec.rb
+++ b/spec/apkstats_spec.rb
@@ -4,22 +4,67 @@ require File.expand_path("spec_helper", __dir__)
 
 module Danger
   describe Danger::DangerApkstats do
+    before do
+      ENV.delete('ANDROID_HOME')
+      ENV.delete('ANDROID_SDK_ROOT')
+    end
+
     it "should be a plugin" do
       expect(Danger::DangerApkstats.new(nil)).to be_a Danger::Plugin
     end
 
-    #
-    # You should test your custom attributes and methods here
-    #
     describe "with Dangerfile" do
-      before do
-        @dangerfile = testing_dangerfile
-        @my_plugin = @dangerfile.apkstats
+      let(:dangerfile) { testing_dangerfile }
+      let(:apkstats) { dangerfile.apkstats }
 
-        # mock the PR data
-        # you can then use this, eg. github.pr_author, later in the spec
+      before do
         json = File.read(fixture_path + "github_pr.json")
-        allow(@my_plugin.github).to receive(:pr_json).and_return(json)
+        allow(apkstats.github).to receive(:pr_json).and_return(json)
+      end
+
+      # compatibility
+      describe "#command_path=" do
+        context "unless command_path is given" do
+          it { expect { apkstats.send(:apkanalyzer_command) }.to raise_error(Danger::DangerApkstats::Error) }
+
+          context "with ANDROID_HOME" do
+            before do
+              ENV['ANDROID_HOME'] = "dummy"
+            end
+
+            it { expect(apkstats.send(:apkanalyzer_command)).to be_kind_of(Apkstats::Command::ApkAnalyzer) }
+          end
+        end
+
+        context "if command_path is given" do
+          before do
+            apkstats.command_path = "dummy"
+          end
+
+          it { expect(apkstats.send(:apkanalyzer_command)).to be_kind_of(Apkstats::Command::ApkAnalyzer) }
+        end
+      end
+
+      describe "#apkanalyzer_path=" do
+        context "unless analyzer_path is given" do
+          it { expect { apkstats.send(:apkanalyzer_command) }.to raise_error(Danger::DangerApkstats::Error) }
+
+          context "with ANDROID_HOME" do
+            before do
+              ENV['ANDROID_HOME'] = "dummy"
+            end
+
+            it { expect(apkstats.send(:apkanalyzer_command)).to be_kind_of(Apkstats::Command::ApkAnalyzer) }
+          end
+        end
+
+        context "if analyzer_path is given" do
+          before do
+            apkstats.apkanalyzer_path = "dummy"
+          end
+
+          it { expect(apkstats.send(:apkanalyzer_command)).to be_kind_of(Apkstats::Command::ApkAnalyzer) }
+        end
       end
     end
   end

--- a/spec/apkstats_spec.rb
+++ b/spec/apkstats_spec.rb
@@ -5,8 +5,8 @@ require File.expand_path("spec_helper", __dir__)
 module Danger
   describe Danger::DangerApkstats do
     before do
-      ENV.delete('ANDROID_HOME')
-      ENV.delete('ANDROID_SDK_ROOT')
+      ENV.delete("ANDROID_HOME")
+      ENV.delete("ANDROID_SDK_ROOT")
     end
 
     it "should be a plugin" do
@@ -29,7 +29,7 @@ module Danger
 
           context "with ANDROID_HOME" do
             before do
-              ENV['ANDROID_HOME'] = "dummy"
+              ENV["ANDROID_HOME"] = "dummy"
             end
 
             it { expect(apkstats.send(:apkanalyzer_command)).to be_kind_of(Apkstats::Command::ApkAnalyzer) }
@@ -51,7 +51,7 @@ module Danger
 
           context "with ANDROID_HOME" do
             before do
-              ENV['ANDROID_HOME'] = "dummy"
+              ENV["ANDROID_HOME"] = "dummy"
             end
 
             it { expect(apkstats.send(:apkanalyzer_command)).to be_kind_of(Apkstats::Command::ApkAnalyzer) }

--- a/spec/command/apk_analyzer_spec.rb
+++ b/spec/command/apk_analyzer_spec.rb
@@ -17,7 +17,7 @@ module Apkstats::Command
     end
 
     context "command" do
-      let(:command) { ApkAnalyzer.new({}) }
+      let(:command) { ApkAnalyzer.new(command_path: ENV.fetch("APKANALYZER_PATH")) }
 
       it "file_size should return apk size" do
         expect(command.file_size(apk_base)).to eq(1_621_248.to_s)

--- a/spec/command/apk_analyzer_spec.rb
+++ b/spec/command/apk_analyzer_spec.rb
@@ -12,8 +12,7 @@ module Apkstats::Command
     let(:apk_other5) { fixture_path + "app-other5.apk" }
     let(:apk_method64k) { fixture_path + "app-method64k.apk" }
 
-    it "should use custom path if set" do
-      expect(ApkAnalyzer.new({}).command_path).to eq("#{ENV.fetch('ANDROID_HOME')}/tools/bin/apkanalyzer")
+    it "should use command_path" do
       expect(ApkAnalyzer.new(command_path: "/y/z").command_path).to eq("/y/z")
     end
 


### PR DESCRIPTION
According to https://developer.android.com/studio/command-line/variables#envar, ANDROID_HOME has been deprecated and ANDROID_SDK_ROOT with the fallback strategy is introduced.
It would be better to avoid using such environment variables than imitating the fallback strategy.