### PR TITLE
Allow Ruby 2.6 for now

### DIFF
--- a/.github/actions/setup-ruby/action.yml
+++ b/.github/actions/setup-ruby/action.yml
@@ -5,5 +5,5 @@ runs:
   steps:
     - uses: ruby/setup-ruby@v1
       with:
-        ruby-version: '2.7'
+        ruby-version: '2.6'
         bundler-cache: true

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -13,6 +13,7 @@ jobs:
       fail-fast: true
       matrix:
         ruby-version:
+          - '2.6'
           - '2.7'
           - '3.0'
           - '3.1'

--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -7,7 +7,7 @@ AllCops:
     - 'vendor/**/*'
     - 'spec/fixtures/**/*'
     - 'tmp/**/*'
-  TargetRubyVersion: 2.7
+  TargetRubyVersion: 2.6
 
 Metrics/ModuleLength:
   Exclude:

--- a/Rakefile
+++ b/Rakefile
@@ -26,8 +26,8 @@ end
 
 desc "Check the precoditions of the release flow"
 task :check_release, [:version] do |_, args|
-  new_version = args.version&.gsub(/\Av/, '') or raise 'version argument is required'
+  new_version = args.version&.gsub(/\Av/, "") or raise "version argument is required"
 
-  require_relative 'lib/apkstats/gem_version'
+  require_relative "lib/apkstats/gem_version"
   raise "Ver. #{Apkstats::VERSION} is defined but #{new_version} has been requested." unless Apkstats::VERSION == new_version
 end

--- a/danger-apkstats.gemspec
+++ b/danger-apkstats.gemspec
@@ -47,5 +47,5 @@ Gem::Specification.new do |spec|
   # This will stop test execution and let you inspect the results
   spec.add_development_dependency "pry"
 
-  spec.required_ruby_version = ">= 2.7"
+  spec.required_ruby_version = ">= 2.6.0"
 end


### PR DESCRIPTION
Ruby 2.6 has already been EOL so I believe it's not running in production now. However, this plugin will run on CI environment so some of lazy people has not upgraded Ruby version.